### PR TITLE
Task/bread to toaster

### DIFF
--- a/toast/toast/toastBot.py
+++ b/toast/toast/toastBot.py
@@ -165,6 +165,11 @@ class ToastBot(Node):
             self.get_logger().debug(f'MPI PlanPath pT:{pathType} \n goal:{goal}')
             await self.mpi.planPath(pathType, goal, execute=True)
             
+            # Drop the bread into the toaster slot
+            # Close the gripper
+            self.get_logger().debug('Opening Gripper')
+            await self.mpi.operateGripper(openGripper=True)
+            
             # Increment bread number so franka knows which slice to grab
             self.breadNumber += 1 
         return response

--- a/toast/toast/toastBot.py
+++ b/toast/toast/toastBot.py
@@ -57,6 +57,19 @@ class ToastBot(Node):
                                          [section1Shape, section2Shape, pedastleShape])
 
         return response
+    
+    async def breadToToaster_callback(self, request, response):
+        """Move a piece of bread from the loaf holder to the toaster.
+        
+        This function moves the gripper to a piece of bread, grips the piece of bread, 
+        moves the piece of bread to the toaster, then releasses the bread.
+
+        :param request: The request object, typically an empty placeholder for this operation.
+        :type request: std_msgs/Empty
+        :param response: The response object to be returned after completing the operation.
+        :type response: std_msgs/Empty
+        """
+        pass
 
 
 def main(args=None):

--- a/toast/toast/toastBot.py
+++ b/toast/toast/toastBot.py
@@ -97,12 +97,10 @@ class ToastBot(Node):
                     self.get_logger().info(f'Transform connectivity exception: {e}')
             except tf2_ros.ExtrapolationException as e:
                     self.get_logger().info(f'Transform extrapolation exception: {e}')
-            
             ########## Set theses value to match real world
             sliceOffsetX = 0.0
             sliceOffsetZ = 0.0
             ##########
-            
             goal = [
                 baseLoafTrans.transform.translation.x + sliceOffsetX * self.breadNumber,
                 baseLoafTrans.transform.translation.y,
@@ -138,8 +136,37 @@ class ToastBot(Node):
             self.get_logger().debug(f'MPI PlanPath pT:{pathType} \n goal:{goal}')
             await self.mpi.planPath(pathType, goal, execute=True)
             
+            # Move the bread to be directly over the toaster slot
+            try:
+                baseToasterTrans = self.buffer.lookup_transform(
+                        'base_link', 'toaster', rclpy.time.Time())  ########### Is this the correct transform?
+            except tf2_ros.LookupException as e:
+                    self.get_logger().info(f'Tranform lookup exception: {e}')
+            except tf2_ros.ConnectivityException as e:
+                    self.get_logger().info(f'Transform connectivity exception: {e}')
+            except tf2_ros.ExtrapolationException as e:
+                    self.get_logger().info(f'Transform extrapolation exception: {e}')
+            ########## Set theses value to match real world
+            slotOffsetX = 0.0
+            toasterOffsetX = 0.0
+            toasterOffsetY = 0.0
+            toasterOffsetZ = 0.0
+            ##########
+            goal = [
+                baseToasterTrans.transform.translation.x + toasterOffsetX + self.breadNumber % 2 * slotOffsetX,
+                baseToasterTrans.transform.translation.y + toasterOffsetY,
+                baseToasterTrans.transform.translation.z + toasterOffsetZ,
+                baseToasterTrans.transform.rotation.x,
+                baseToasterTrans.transform.rotation.y,
+                baseToasterTrans.transform.rotation.z,
+                baseToasterTrans.transform.rotation.w
+                ]
+            pathType = 'POSE'
+            self.get_logger().debug(f'MPI PlanPath pT:{pathType} \n goal:{goal}')
+            await self.mpi.planPath(pathType, goal, execute=True)
             
-            self.breadNumber += 1 # So franka knows which slice to grab
+            # Increment bread number so franka knows which slice to grab
+            self.breadNumber += 1 
         return response
 
 

--- a/toast/toast/toastBot.py
+++ b/toast/toast/toastBot.py
@@ -19,6 +19,9 @@ class ToastBot(Node):
         self.mpi = MotionPlanningInterface(self)
         self.setScene = self.create_service(Empty, 'buildScene', self.setScene_callback,
                                             callback_group=client_cb_group)
+        self.breadToToaster = self.create_service(Empty, 'breadToToaster', self.breadToToaster_callback,
+                                                  callback_group=client_cb_group)
+        self.breadNumber = 0 # So the franka picks the correct piece of bread
 
     async def setScene_callback(self, request, response):
         """
@@ -69,7 +72,12 @@ class ToastBot(Node):
         :param response: The response object to be returned after completing the operation.
         :type response: std_msgs/Empty
         """
-        pass
+        self.get_logger().info("BreadToToaster Callback called!")
+        
+        # Move the gripper to be above a slice of toast
+        
+        self.breadNumber += 1 # So franka knows which slice to grab
+        return response
 
 
 def main(args=None):

--- a/toast/toast/toastBot.py
+++ b/toast/toast/toastBot.py
@@ -93,13 +93,18 @@ class ToastBot(Node):
                 self.get_logger().info(f'Transform extrapolation exception: {e}')
         
         #### Set theses value to match real world
-        
+        slice_offset_x = 0
+        slice_offset_z = 0
         #### 
         current_pose = await self.mpi.getCurrentPose()
         goal = [
-            base_loaf_trans.transform.translation.x + slice_offset * self.breadNumber,
+            base_loaf_trans.transform.translation.x + slice_offset_x * self.breadNumber,
             base_loaf_trans.transform.translation.y,
-            base_loaf_trans.transform.translation.z + 
+            base_loaf_trans.transform.translation.z + slice_offset_z,
+            base_loaf_trans.transform.rotation.x,
+            base_loaf_trans.transform.rotation.y,
+            base_loaf_trans.transform.rotation.z,
+            base_loaf_trans.transform.rotation.w
             ]
         
         self.breadNumber += 1 # So franka knows which slice to grab


### PR DESCRIPTION
Moves from ready position over the next available slice of bread, moves down to the bread, closes the gripper on the bread, moves up out of the loaf holder, moves over an available toaster slot, and opens the gripper to drop the bread into the toaster. 

Many things need to be changed: Tansforms, offsets, etc.